### PR TITLE
A 404 from the users API means a new user

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(name='osmcha',
           'PyYAML'
       ],
       extras_require={
-          'test': ['pytest'],
+          'test': ['pytest', 'responses'],
       },
       entry_points="""
       [console_scripts]


### PR DESCRIPTION
Presently, any error during a request from the user's API is handled as a non-new user. But, a `HTTP 404` is different. A `404` from the user's API says that the user is new.

## Uncertainties
- From what I understood, every network request should have a response when using the `responses` package to mock. Ex: Without a mock for the changeset download request, the test failed with.

```
ConnectionError: Connection refused: GET http://www.openstreetmap.org/api/0.6/changeset/46887130/download
```

---

cc: @batpad @willemarcel @amishas157 