### PR TITLE
Add mapwith.ai/rapidtest as trusted iD host.

### DIFF
--- a/osmcha/changeset.py
+++ b/osmcha/changeset.py
@@ -358,7 +358,8 @@ class Analyse(object):
                     'projets.pavie.info/id-indoor',
                     'maps.mapcat.com/edit',
                     'id.softek.ir',
-                    'mapwith.ai/rapid'
+                    'mapwith.ai/rapid',
+                    'mapwith.ai/rapidtest'
                     ]
                 if self.host.split('://')[-1].strip('/') not in trusted_hosts:
                     self.label_suspicious('Unknown iD instance')


### PR DESCRIPTION
Fixes https://github.com/mapbox/osmcha-frontend/issues/380