### PR TITLE
v0.5.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+before_install:
+  - sudo apt-get update -q
+  - sudo apt-get install -y libgnutls28-dev
 install:
   - "pip install coveralls"
   - "pip install -e .[test]"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+[0.5.0] - 2019-08-19
+
+- Include new suspicion reasons based on 'warnings:' tags added by iD
+- Include RapiD test instance as trusted host
+
 [0.4.11] - 2019-07-24
 
 - Fix "yandex panorama" whitelisting

--- a/osmcha/__init__.py
+++ b/osmcha/__init__.py
@@ -1,2 +1,2 @@
 # osmcha
-__version__ = '0.4.11'
+__version__ = '0.5.0'

--- a/osmcha/changeset.py
+++ b/osmcha/changeset.py
@@ -264,6 +264,21 @@ class Analyse(object):
         self.excluded_words = excluded_words
         self.illegal_sources = illegal_sources
         self.suspect_words = suspect_words
+        self.enabled_warnings = {
+            'warnings:almost_junction': 'Almost junction',
+            'warnings:close_nodes': 'Very close points',
+            'warnings:crossing_ways': 'Crossing ways',
+            'warnings:disconnected_way': 'Disconnected way',
+            'warnings:generic_name': 'Generic name',
+            'warnings:impossible_oneway': 'Impossible oneway',
+            'warnings:incompatible_source': 'suspect_word',
+            'warnings:missing_role': 'Missing role',
+            'warnings:missing_tag': 'Missing tag',
+            'warnings:outdated_tags': 'Outdated tags',
+            'warnings:private_data': 'Private information',
+            'warnings:tag_suggests_area': 'Line tagged as area',
+            'warnings:unsquare_way': 'Unsquare corners',
+            }
 
     def set_fields(self, changeset):
         """Set the fields of this class with the metadata of the analysed
@@ -286,6 +301,9 @@ class Analyse(object):
         self.suspicion_reasons = []
         self.is_suspect = False
         self.powerfull_editor = False
+        self.warning_tags = [
+            i for i in changeset.keys() if i.startswith('warnings:')
+            ]
 
     def label_suspicious(self, reason):
         """Add suspicion reason and set the suspicious flag."""
@@ -297,9 +315,15 @@ class Analyse(object):
         self.count()
         self.verify_words()
         self.verify_user()
+        self.verify_warning_tags()
 
         if self.review_requested == 'yes':
             self.label_suspicious('Review requested')
+
+    def verify_warning_tags(self):
+        for tag in self.warning_tags:
+            if tag in self.enabled_warnings.keys():
+                self.label_suspicious(self.enabled_warnings.get(tag))
 
     def verify_user(self):
         """Verify if the changeset was made by a inexperienced mapper (anyone
@@ -403,7 +427,8 @@ class Analyse(object):
         fields_to_remove = [
             'create_threshold', 'modify_threshold', 'illegal_sources',
             'delete_threshold', 'percentage', 'top_threshold', 'suspect_words',
-            'excluded_words', 'host', 'review_requested',
+            'excluded_words', 'host', 'review_requested', 'warning_tags',
+            'enabled_warnings'
             ]
         for field in fields_to_remove:
             ch_dict.pop(field)

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from datetime import datetime
-
 from pytest import raises
 from shapely.geometry import Polygon
 
@@ -582,6 +581,26 @@ def test_get_dict():
     assert 'delete' in ch.get_dict().keys()
     assert len(ch.get_dict().keys()) == 15
 
+    # An iD changeset with warnings:
+    ch = Analyse(72783703)
+    ch.full_analysis()
+    assert 'id' in ch.get_dict().keys()
+    assert 'user' in ch.get_dict().keys()
+    assert 'uid' in ch.get_dict().keys()
+    assert 'editor' in ch.get_dict().keys()
+    assert 'bbox' in ch.get_dict().keys()
+    assert 'date' in ch.get_dict().keys()
+    assert 'comment' in ch.get_dict().keys()
+    assert 'source' in ch.get_dict().keys()
+    assert 'imagery_used' in ch.get_dict().keys()
+    assert 'is_suspect' in ch.get_dict().keys()
+    assert 'powerfull_editor' in ch.get_dict().keys()
+    assert 'suspicion_reasons' in ch.get_dict().keys()
+    assert 'create' in ch.get_dict().keys()
+    assert 'modify' in ch.get_dict().keys()
+    assert 'delete' in ch.get_dict().keys()
+    assert len(ch.get_dict().keys()) == 15
+
     # A JOSM changeset
     ch = Analyse(46315321)
     ch.full_analysis()
@@ -673,3 +692,153 @@ def test_changeset_with_review_requested():
     changeset.full_analysis()
     assert 'Review requested' in changeset.suspicion_reasons
     assert changeset.is_suspect
+
+
+def test_changeset_with_warning_tag_almost_junction():
+    ch_dict = {
+        'created_by': 'iD',
+        'created_at': '2019-04-25T18:08:46Z',
+        'host': 'https://www.openstreetmap.org/edit',
+        'comment': 'add pois',
+        'id': '1',
+        'user': 'JustTest',
+        'uid': '123123',
+        'warnings:almost_junction': '1',
+        'warnings:missing_role': '1',
+        'warnings:missing_tag': '1',
+        'warnings:private_data': '1',
+        'warnings:tag_suggests_area': '1',
+        'warnings:unsquare_way': '1',
+        'bbox': Polygon([
+            (-71.0646843, 44.2371354), (-71.0048652, 44.2371354),
+            (-71.0048652, 44.2430624), (-71.0646843, 44.2430624),
+            (-71.0646843, 44.2371354)
+            ])
+        }
+    changeset = Analyse(ch_dict)
+    changeset.full_analysis()
+    assert 'Almost junction' in changeset.suspicion_reasons
+    assert 'Missing role' in changeset.suspicion_reasons
+    assert 'Missing tag' in changeset.suspicion_reasons
+    assert 'Private information' in changeset.suspicion_reasons
+    assert 'Line tagged as area' in changeset.suspicion_reasons
+    assert 'Unsquare corners' in changeset.suspicion_reasons
+    assert changeset.is_suspect
+
+
+def test_changeset_with_warning_tag_close_nodes():
+    ch_dict = {
+        'created_by': 'iD',
+        'created_at': '2019-04-25T18:08:46Z',
+        'host': 'https://www.openstreetmap.org/edit',
+        'comment': 'add pois',
+        'id': '1',
+        'user': 'JustTest',
+        'uid': '123123',
+        'warnings:close_nodes': '1',
+        'bbox': Polygon([
+            (-71.0646843, 44.2371354), (-71.0048652, 44.2371354),
+            (-71.0048652, 44.2430624), (-71.0646843, 44.2430624),
+            (-71.0646843, 44.2371354)
+            ])
+        }
+    changeset = Analyse(ch_dict)
+    changeset.full_analysis()
+    assert 'Very close points' in changeset.suspicion_reasons
+    assert changeset.is_suspect
+
+
+def test_changeset_with_warning_tag_crossing_ways():
+    ch_dict = {
+        'created_by': 'iD',
+        'created_at': '2019-04-25T18:08:46Z',
+        'host': 'https://www.openstreetmap.org/edit',
+        'comment': 'add pois',
+        'id': '1',
+        'user': 'JustTest',
+        'uid': '123123',
+        'warnings:crossing_ways': '1',
+        'bbox': Polygon([
+            (-71.0646843, 44.2371354), (-71.0048652, 44.2371354),
+            (-71.0048652, 44.2430624), (-71.0646843, 44.2430624),
+            (-71.0646843, 44.2371354)
+            ])
+        }
+    changeset = Analyse(ch_dict)
+    changeset.full_analysis()
+    assert 'Crossing ways' in changeset.suspicion_reasons
+    assert changeset.is_suspect
+
+
+def test_changeset_with_warning_tag_disconnected_way():
+    ch_dict = {
+        'created_by': 'iD',
+        'created_at': '2019-04-25T18:08:46Z',
+        'host': 'https://www.openstreetmap.org/edit',
+        'comment': 'add pois',
+        'id': '1',
+        'user': 'JustTest',
+        'uid': '123123',
+        'warnings:disconnected_way': '4',
+        'warnings:generic_name': '4',
+        'warnings:impossible_oneway': '4',
+        'warnings:incompatible_source': '4',
+        'warnings:outdated_tags': '9',
+        'bbox': Polygon([
+            (-71.0646843, 44.2371354), (-71.0048652, 44.2371354),
+            (-71.0048652, 44.2430624), (-71.0646843, 44.2430624),
+            (-71.0646843, 44.2371354)
+            ])
+        }
+    changeset = Analyse(ch_dict)
+    changeset.full_analysis()
+    assert 'Disconnected way' in changeset.suspicion_reasons
+    assert 'Generic name' in changeset.suspicion_reasons
+    assert 'Impossible oneway' in changeset.suspicion_reasons
+    assert 'suspect_word' in changeset.suspicion_reasons
+    assert 'Outdated tags' in changeset.suspicion_reasons
+    assert changeset.is_suspect
+
+
+def test_changeset_with_warning_tag_fix_me():
+    ch_dict = {
+        'created_by': 'iD',
+        'created_at': '2019-04-25T18:08:46Z',
+        'host': 'https://www.openstreetmap.org/edit',
+        'comment': 'add pois',
+        'id': '1',
+        'user': 'JustTest',
+        'uid': '123123',
+        'warnings:fix_me': '0',
+        'bbox': Polygon([
+            (-71.0646843, 44.2371354), (-71.0048652, 44.2371354),
+            (-71.0048652, 44.2430624), (-71.0646843, 44.2430624),
+            (-71.0646843, 44.2371354)
+            ])
+        }
+    changeset = Analyse(ch_dict)
+    changeset.full_analysis()
+    assert changeset.suspicion_reasons == []
+    assert not changeset.is_suspect
+
+
+def test_changeset_with_warning_tag_invalid_format():
+    ch_dict = {
+        'created_by': 'iD',
+        'created_at': '2019-04-25T18:08:46Z',
+        'host': 'https://www.openstreetmap.org/edit',
+        'comment': 'add pois',
+        'id': '1',
+        'user': 'JustTest',
+        'uid': '123123',
+        'warnings:invalid_format': '0',
+        'bbox': Polygon([
+            (-71.0646843, 44.2371354), (-71.0048652, 44.2371354),
+            (-71.0048652, 44.2430624), (-71.0646843, 44.2430624),
+            (-71.0646843, 44.2371354)
+            ])
+        }
+    changeset = Analyse(ch_dict)
+    changeset.full_analysis()
+    assert changeset.suspicion_reasons == []
+    assert not changeset.is_suspect


### PR DESCRIPTION
- include new suspicion reasons based on 'warnings:' tags added by iD (solves https://github.com/mapbox/osmcha-frontend/issues/376)
- Include RapiD test instance as trusted host (solves https://github.com/mapbox/osmcha-frontend/issues/380)