### PR TITLE
Update links to whitelisted iD instances

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,10 +143,10 @@ Unknown iD instance
 -------------------
 
 Verify the changesets created with iD editor to check the host instance. The trusted
-iD instances are: `OSM.org <http://osm.org/>`_, `Strava <https://strava.github.io/iD/>`_,
-`ImproveOSM <http://improveosm.org>`_, `iDeditor <http://preview.ideditor.com/master/>`_,
-`Hey <https://hey.mapbox.com/iD-internal/>`_, `Mapcat <maps.mapcat.com/edit>`_ and
-`iD indoor <http://projets.pavie.info/id-indoor/>`_, `Softek <id.softek.ir>`_ and `RapiD <mapwith.ai/rapid>`_.
+iD instances are: `OSM.org <https://osm.org/>`_, `Strava <https://strava.github.io/iD/>`_,
+`ImproveOSM <https://improveosm.org>`_, `iDeditor <https://preview.ideditor.com/master/>`_,
+`Hey <https://hey.mapbox.com/iD-internal/>`_, `Mapcat <https://maps.mapcat.com/edit>`_ and
+`iD indoor <http://projets.pavie.info/id-indoor/>`_, `Softek <https://id.softek.ir>`_ and `RapiD <https://mapwith.ai/rapid>`_.
 
 If you deploy an iD instance for an organization, please let us know so we can whitelist it.
 


### PR DESCRIPTION
- Updated from http to https for sites which support it
- Added `https` to links. Otherwise, on Github they end up with links like this https://github.com/willemarcel/osmcha/blob/master/mapwith.ai/rapid instead of https://mapwith.ai/rapid