### PR TITLE
Add 'ideditor.amazon.com' to the list of trusted hosts 

### DIFF
--- a/osmcha/changeset.py
+++ b/osmcha/changeset.py
@@ -394,6 +394,7 @@ class Analyse(object):
                     'strava.github.io',
                     'preview.ideditor.com',
                     'ideditor.netlify.app',
+                    'ideditor.amazon.com',
                     'hey.mapbox.com',
                     'projets.pavie.info',
                     'maps.mapcat.com',

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -514,7 +514,7 @@ def test_verify_id_editor_amazon_is_known_instance():
     ch_dict = {
         'created_by': 'iD 2.17.3',
         'host': 'https://ideditor.amazon.com/',
-        'created_at': '2015-04-25T18:08:46Z',
+        'created_at': '2020-09-25T18:08:46Z',
         'comment': 'add pois',
         'comments_count': '4',
         'id': '1',

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -507,6 +507,32 @@ def test_verify_editor_netlify_id_is_known_instance():
     assert ch.is_suspect is False
 
 
+def test_verify_id_editor_amazon_is_known_instance():
+    """Test if iD is not a powerfull_editor and if 'Unknown iD instance' is added
+    to suspicion_reasons.
+    """
+    ch_dict = {
+        'created_by': 'iD 2.17.3',
+        'host': 'https://ideditor.amazon.com/',
+        'created_at': '2015-04-25T18:08:46Z',
+        'comment': 'add pois',
+        'comments_count': '4',
+        'id': '1',
+        'user': 'JustTest',
+        'uid': '123123',
+        'bbox': Polygon([
+            (-71.0646843, 44.2371354), (-71.0048652, 44.2371354),
+            (-71.0048652, 44.2430624), (-71.0646843, 44.2430624),
+            (-71.0646843, 44.2371354)
+            ])
+        }
+    ch = Analyse(ch_dict)
+    ch.verify_editor()
+    assert ch.powerfull_editor is False
+    assert 'Unknown iD instance' not in ch.suspicion_reasons
+    assert ch.is_suspect is False
+
+
 def test_verify_hotosm_id_is_known_instance():
     """Test if iD is not a powerfull_editor and if 'Unknown iD instance' is added
     to suspicion_reasons.


### PR DESCRIPTION
This pull request is regarding whitelisting an iD instance. I have added 'ideditor.amazon.com' to the list of trusted hosts and have also included a unit test for the change . Please take a look and do the needful.