### PR TITLE
Add lyft.com as trusted host and corresp test.

### DIFF
--- a/osmcha/changeset.py
+++ b/osmcha/changeset.py
@@ -388,6 +388,7 @@ class Analyse(object):
                     'tasks.teachosm.org',
                     'tasks-stage.hotosm.org',
                     'tasks.hotosm.org',
+                    'lyft.com',
                     ]
                 if self.host.split('://')[-1].split('/')[0] not in trusted_hosts:
                     self.label_suspicious('Unknown iD instance')

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -533,6 +533,32 @@ def test_verify_id_editor_amazon_is_known_instance():
     assert ch.is_suspect is False
 
 
+def test_verify_id_editor_lyft_is_known_instance():
+    """Test if iD is not a powerfull_editor and 'Unknown iD instance' not added
+    to suspicion_reasons.
+    """
+    ch_dict = {
+        'created_by': 'iD 2.17.3',
+        'host': 'https://lyft.com/',
+        'created_at': '2020-09-25T18:08:46Z',
+        'comment': 'add pois',
+        'comments_count': '4',
+        'id': '1',
+        'user': 'JustTest',
+        'uid': '123123',
+        'bbox': Polygon([
+            (-71.0646843, 44.2371354), (-71.0048652, 44.2371354),
+            (-71.0048652, 44.2430624), (-71.0646843, 44.2430624),
+            (-71.0646843, 44.2371354)
+            ])
+        }
+    ch = Analyse(ch_dict)
+    ch.verify_editor()
+    assert ch.powerfull_editor is False
+    assert 'Unknown iD instance' not in ch.suspicion_reasons
+    assert ch.is_suspect is False
+
+
 def test_verify_hotosm_id_is_known_instance():
     """Test if iD is not a powerfull_editor and if 'Unknown iD instance' is added
     to suspicion_reasons.


### PR DESCRIPTION
@willemarcel This branch adds lyft.com as a trusted host so that our changesets are not flagged as unknown iD instance.  Please take a look and let me know if it needs any changes!
