### PR TITLE
Add tasks.mapwith.ai to iD allowlist

### DIFF
--- a/osmcha/changeset.py
+++ b/osmcha/changeset.py
@@ -385,6 +385,8 @@ class Analyse(object):
                     'maps.mapcat.com',
                     'id.softek.ir',
                     'mapwith.ai',
+                    'tasks.mapwith.ai',
+                    'tasks-staging.mapwith.ai',
                     'tasks.teachosm.org',
                     'tasks-stage.hotosm.org',
                     'tasks.hotosm.org',


### PR DESCRIPTION
This PR simply adds the MapWithAI TM instances to the allowlist since they both have embedded iD and RapiD.