### PR TITLE
Replace dash-separated keys in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 dry-run = 1
 
 [metadata]
-description-file=README.rst
+description_file=README.rst
 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
Setuptools deprecated dash-seperated keys in [v54.1.10 (2021)](https://setuptools.pypa.io/en/latest/history.html#id855) and they're advising [projects update before 2026](https://setuptools.pypa.io/en/latest/history.html#v78-0-2).